### PR TITLE
proper playfield scaling and circle size support

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -35,7 +35,8 @@ impl Camera {
     }
 
     pub fn scale(&mut self, scale: f32) {
-        self.view = Matrix4::identity()
+        self.view
+            = Matrix4::identity()
             * Matrix4::from_scale(scale);
     }
 

--- a/src/shaders/hit_circle.wgsl
+++ b/src/shaders/hit_circle.wgsl
@@ -4,8 +4,11 @@ struct CameraUniform {
     view_proj: mat4x4<f32>,
 };
 
-@group(1) @binding(0) // 1.
+@group(1) @binding(0)
 var<uniform> camera: CameraUniform;
+
+@group(2) @binding(0)
+var<uniform> cs: f32;
 
 struct VertexInput {
 	@location(0) pos: vec2<f32>,
@@ -41,7 +44,7 @@ fn vs_main(
 
     out.clip_position = camera.view_proj 
 		* model_matrix
-		* vec4<f32>(model.pos, 0.0, 1.0);
+		* vec4<f32>(model.pos * cs, 0.0, 1.0);
 
     return out;
 }


### PR DESCRIPTION
pr adds a new uniform to scale circles in the shader

right now the uniform is only used to scale circles, but the bind group can be expanded to be used for other properties which operate on circle vertices before the view matrix is applied